### PR TITLE
Fix: Standard roles

### DIFF
--- a/standard_roles/deletes_a_standard_role.ts
+++ b/standard_roles/deletes_a_standard_role.ts
@@ -2,7 +2,7 @@ import api from '../api';
 
 async function deleteStandardRole(teamId: number, roleId: number): Promise<void> {
   try {
-    const response = await api.delete(`/api/${teamId}/rate/${roleId}`);
+    const response = await api.delete(`/api/${teamId}/role/${roleId}`);
     console.log(response.status);
   } catch (error) {
     console.error(error);

--- a/standard_roles/fetch_all_standard_roles.ts
+++ b/standard_roles/fetch_all_standard_roles.ts
@@ -1,10 +1,28 @@
 import api from '../api';
 
+// Define the structure of a standard role
+interface StandardRole {
+  deleted: boolean;
+  description: string | null;
+  discarded_at: string | null; // ISO-8601 formatted date or null
+  id: number;
+  is_default: boolean;
+  name: string;
+  position_memberships: any | null; 
+  team_id: number;
+}
+
+// Define the response type
+interface StandardRolesResponse {
+  roles: StandardRole[];
+}
+
 async function fetchAllStandardRoles(teamId: number): Promise<void> {
   try {
     const response = await api.get(`/api/${teamId}/role`);
-    const standardRoles = (response.data as { roles: any }).roles;
+    const standardRoles = (response.data as StandardRolesResponse).roles;
     console.log(standardRoles)
+    console.log('Total Roles Count:', standardRoles?.length ?? 0);
   } catch (error) {
     console.error(error);
   }

--- a/standard_roles/fetch_all_standard_roles.ts
+++ b/standard_roles/fetch_all_standard_roles.ts
@@ -3,7 +3,7 @@ import api from '../api';
 async function fetchAllStandardRoles(teamId: number): Promise<void> {
   try {
     const response = await api.get(`/api/${teamId}/role`);
-    const standardRoles = response.data.roles;
+    const standardRoles = (response.data as { roles: any }).roles;
     console.log(standardRoles)
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Fixed incorrect API endpoint in `deleteStandardRole` function by changing `/rate/` to `/role/`.
- Added type assertion for the roles data in `fetchAllStandardRoles` function to ensure type safety.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deletes_a_standard_role.ts</strong><dd><code>Fix incorrect API endpoint in delete function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

standard_roles/deletes_a_standard_role.ts

- Corrected the API endpoint from `/rate/` to `/role/`.



</details>


  </td>
  <td><a href="https://github.com/LifeCoded/mosaic-api-examples/pull/39/files#diff-b8b8b108623524109a856d099b1a79980234029e8f2482cd13de4a4ab409fc32">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>fetch_all_standard_roles.ts</strong><dd><code>Add type assertion for roles in fetch function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

standard_roles/fetch_all_standard_roles.ts

- Added type assertion to response data for roles.



</details>


  </td>
  <td><a href="https://github.com/LifeCoded/mosaic-api-examples/pull/39/files#diff-b40128207ab23b12e9b7cc94184657d3ee657cd1b9422bbd598e8ce67d582ade">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix incorrect API endpoint and add type assertions for roles data in standard roles functions.
> 
>   - **Bug Fix**:
>     - Corrected API endpoint in `deleteStandardRole` function from `/rate/` to `/role/` in `deletes_a_standard_role.ts`.
>   - **Type Safety**:
>     - Added type assertion for roles data in `fetchAllStandardRoles` function in `fetch_all_standard_roles.ts` by defining `StandardRole` and `StandardRolesResponse` interfaces.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=LifeCoded%2Fmosaic-api-examples&utm_source=github&utm_medium=referral)<sup> for f1410b66186ceb93b27944e751b4a9afa511f8b0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->