### PR TITLE
Fix: Refactor query string generation

### DIFF
--- a/activity_phases/fetch_all_activity_phases.ts
+++ b/activity_phases/fetch_all_activity_phases.ts
@@ -19,7 +19,7 @@ async function fetchAllActivityPhases(
   queryParams: ActivityPhaseQueryParams
 ): Promise<void> {
   try {
-    const queryString = qs.stringify(queryParams, { addQueryPrefix: true });
+    const queryString = qs.stringify(queryParams, { addQueryPrefix: true, arrayFormat: "brackets" });
     const response = await api.get(
       `/api/${teamId}/activity_phase${queryString}`
     );

--- a/calendar_events/fetch_calendar_events.ts
+++ b/calendar_events/fetch_calendar_events.ts
@@ -12,7 +12,7 @@ interface CalendarEventQueryParams {
 
 async function fetchCalendarEvents(teamId: number, queryParams: CalendarEventQueryParams): Promise<void> {
   try {
-    const queryString = qs.stringify(queryParams, { addQueryPrefix: true });
+    const queryString = qs.stringify(queryParams, { addQueryPrefix: true, arrayFormat: "brackets" });
     const response = await api.get(`/api/${teamId}/calendar_event${queryString}`);
     const calendarEvents = (response.data as { calendar_events: any[] }).calendar_events;
     const totalCount = calendarEvents?.length ?? 0;

--- a/check_ins/fetch_check_ins.ts
+++ b/check_ins/fetch_check_ins.ts
@@ -8,7 +8,7 @@ interface CheckInQueryParams {
 
 async function fetchCheckIns(teamId: number, queryParams: CheckInQueryParams): Promise<void> {
   try {
-    const queryString = qs.stringify(queryParams, { addQueryPrefix: true });
+    const queryString = qs.stringify(queryParams, { addQueryPrefix: true, arrayFormat: "brackets" });
     const response = await api.get(`/api/${teamId}/check_in${queryString}`);
     const checkIns = (response.data as { check_ins: any[] }).check_ins;
     const totalCount = checkIns?.length ?? 0;

--- a/entity_rates/fetch_all_entity_rates.ts
+++ b/entity_rates/fetch_all_entity_rates.ts
@@ -19,7 +19,7 @@ async function fetchEntityRates(
   queryParams: EntityRateParams
 ): Promise<void> {
   try {
-    const queryString = qs.stringify(queryParams, { addQueryPrefix: true });
+    const queryString = qs.stringify(queryParams, { addQueryPrefix: true, arrayFormat: "brackets" });
     const response = await api.get(`/api/${teamId}/entity_rate${queryString}`);
     const entityRates = (response.data as { entity_rates: any }).entity_rates;
     console.log(entityRates);

--- a/project_scopes/fetch_all.ts
+++ b/project_scopes/fetch_all.ts
@@ -23,7 +23,7 @@ async function fetchAllScopes(
   queryParams: FetchScopesParams
 ): Promise<void> {
   try {
-    const queryString = qs.stringify(queryParams, { addQueryPrefix: true });
+    const queryString = qs.stringify(queryParams, { addQueryPrefix: true, arrayFormat: "brackets" });
     const response = await api.get(`/api/${teamId}/scope${queryString}`);
     const scopes: any[] = (response.data as { scopes: any[] }).scopes;
     console.log(scopes);

--- a/project_scopes/move_scope_to_new_activity_phase.ts
+++ b/project_scopes/move_scope_to_new_activity_phase.ts
@@ -8,7 +8,7 @@ interface MoveScopesParams {
 }
 
 async function moveScopesToNewActivityPhase(team_id: number, queryParams: MoveScopesParams): Promise<void> {
-  const queryString = qs.stringify(queryParams, { addQueryPrefix: true });
+  const queryString = qs.stringify(queryParams, { addQueryPrefix: true, arrayFormat: "brackets" });
 
   try {
     const response = await api.put(`/api/${team_id}/scope_update_activity_phase`, queryString);

--- a/task_lists/fetch_all_task_lists.ts
+++ b/task_lists/fetch_all_task_lists.ts
@@ -8,7 +8,7 @@ interface TaskListQueryParams {
 
 async function fetchProjectTaskLists(teamId: number, queryParams: TaskListQueryParams): Promise<void> {
   try {
-    const queryString = qs.stringify(queryParams, { addQueryPrefix: true });
+    const queryString = qs.stringify(queryParams, { addQueryPrefix: true, arrayFormat: "brackets" });
     const response = await api.get(`/api/${teamId}/task_list/index${queryString}`);
     const taskLists = (response.data as { task_lists: any[] }).task_lists;
     const totalCount = taskLists?.length ?? 0;

--- a/time_entries/fetch_all_time_entries.ts
+++ b/time_entries/fetch_all_time_entries.ts
@@ -29,7 +29,7 @@ interface TimeEntryQueryParams {
 
 async function fetchAllTimeEntries(teamId: number, queryParams: TimeEntryQueryParams): Promise<void> {
   try {
-    const queryString = qs.stringify(queryParams, { addQueryPrefix: true });
+    const queryString = qs.stringify(queryParams, { addQueryPrefix: true, arrayFormat: "brackets" });
     const response = await api.get(`/api/${teamId}/time_entry${queryString}`);
     let data = response.data as { time_entry: any[] };
     const timeEntries = data.time_entry;

--- a/work_plans/fetch_work_plans.ts
+++ b/work_plans/fetch_work_plans.ts
@@ -19,7 +19,7 @@ interface WorkPlanQueryParams {
 
 async function fetchWorkPlans(teamId: number, queryParams: WorkPlanQueryParams): Promise<void> {
   try {
-    const queryString = qs.stringify(queryParams, { addQueryPrefix: true });
+    const queryString = qs.stringify(queryParams, { addQueryPrefix: true, arrayFormat: "brackets" });
     const response = await api.get(`/api/${teamId}/work_plan/index${queryString}`);
     const data = response.data as { work_plans: any[]; count: number };
     const workPlans = data.work_plans;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor query string generation to use `arrayFormat: "brackets"` for consistent array serialization across multiple API request functions.
> 
>   - **Behavior**:
>     - Updated query string generation to use `arrayFormat: "brackets"` in `qs.stringify()` in `fetchAllActivityPhases`, `fetchCalendarEvents`, and `fetchCheckIns`.
>     - Similar updates in `fetchEntityRates`, `fetchAllScopes`, and `moveScopesToNewActivityPhase`.
>     - Applied the same change in `fetchProjectTaskLists`, `fetchAllTimeEntries`, and `fetchWorkPlans`.
>   - **Misc**:
>     - Ensures consistent array serialization across API requests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=LifeCoded%2Fmosaic-api-examples&utm_source=github&utm_medium=referral)<sup> for c98b3e205a5a361b37507f7d56dcfcc366ea7811. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->